### PR TITLE
feat : key name and path improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,8 +141,11 @@ Enter password to mount: **********
    -------------------------------------------------------
 ```
 
-Going forward, the CLI will ask for the mount password to decrpyt and use these keys. This is how the config will look like when using encrypted keys
+Going forward, the CLI will ask for the mount password to decrpyt and use these keys. This is how the config will look like when using encrypted keys and the keys are present in the default location i.e. `~/.witnesschain/cli/.encrypted_keys`
+> NOTE -
+> If `use_encrypted_keys` is marked `true`, you need to either give the full path(if you want an alternate path to be used) or the name(for the default path) of the gocrptfs encrypted keys as show in the example below
 
+The below example shows how you can use the key names which will be taken from the default path
 ```
 {
   "watchtower_private_keys": [
@@ -157,7 +160,28 @@ Going forward, the CLI will ask for the mount password to decrpyt and use these 
   "gas_limit": 5000000,
   "tx_receipt_timeout": 600,
   "expiry_in_days": 1,
-  "use_encrypted_keys": true,
-  "keys_directory_path": "~/alternate/path/to/your/keys/"
+  "use_encrypted_keys": true
 }
 ```
+
+The below example shows how you can use the key names which will be taken from an alternate path
+```
+{
+  "watchtower_private_keys": [
+    "~/alternate/path/to/your/keys/.encrypted_keys/wt1"
+  ],
+  "operator_private_key": "~/alternate/path/to/your/keys/.encrypted_keys/op1",
+  "operator_registry_address": "0xEf1a89841fd189ba28e780A977ca70eb1A5e985D",
+  "witnesshub_address": "0xD25c2c5802198CB8541987b73A8db4c9BCaE5cC7",
+  "avs_directory_address": "0x135dda560e946695d6f155dacafc6f1f25c1f5af",
+  "eth_rpc_url": "<Mainnet RPC URL>",
+  "chain_id": 1,
+  "gas_limit": 5000000,
+  "tx_receipt_timeout": 600,
+  "expiry_in_days": 1,
+  "use_encrypted_keys": true,
+}
+```
+
+> NOTE -
+> If you are using an alternate path, all the keys present in the config have to be present in the same path. You cannot save the keys in different locations in the same config

--- a/watchtower-operator/config/config.go
+++ b/watchtower-operator/config/config.go
@@ -24,7 +24,6 @@ type OperatorConfig struct {
 	TxReceiptTimeout        int64          `json:"tx_receipt_timeout"`
 	ExpiryInDays            int64          `json:"expiry_in_days"`
 	UseEncryptedKeys        bool           `json:"use_encrypted_keys"`
-	KeysDirectoryPath       string         `json:"keys_directory_path"`
 }
 
 func GetConfigFromContext(cCtx *cli.Context) *OperatorConfig {
@@ -41,11 +40,10 @@ func GetConfigFromContext(cCtx *cli.Context) *OperatorConfig {
 
 	SetDefaultConfigValues(&config)
 
-	if len(config.KeysDirectoryPath) > 0 {
-		wc_common.SetKeysPath(config.KeysDirectoryPath)
-	}
-
 	if config.UseEncryptedKeys {
+		// get the path from the first key, as others should be same
+		// will not work with different paths
+		wc_common.ProcessConfigKeyPath(config.WatchtowerPrivateKeys[0])
 		wc_common.UseEncryptedKeys()
 	}
 

--- a/watchtower-operator/config/l1-operator-config.json.template
+++ b/watchtower-operator/config/l1-operator-config.json.template
@@ -1,10 +1,10 @@
 {
   "watchtower_private_keys": [
-    "<WatchTower1-private-key-name>",
-    "<WatchTower2-private-key-name>",
-    "<WatchTower3-private-key-name>"
+    "<alternate-path(optional) + WatchTower1-private-key-name>",
+    "<alternate-path(optional) + WatchTower2-private-key-name>",
+    "<alternate-path(optional) + WatchTower3-private-key-name>"
   ],
-  "operator_private_key": "<operator-private-key-name>",
+  "operator_private_key": "<alternate-path(optional) + operator-private-key-name>",
   "operator_registry_address": "0xEf1a89841fd189ba28e780A977ca70eb1A5e985D",
   "witnesshub_address": "0xD25c2c5802198CB8541987b73A8db4c9BCaE5cC7",
   "avs_directory_address": "0x135dda560e946695d6f155dacafc6f1f25c1f5af",
@@ -13,6 +13,5 @@
   "gas_limit": "<gas-limit>",
   "tx_receipt_timeout": "<timeout_in_seconds>",
   "expiry": "<expiry_in_days>",
-  "use_encrypted_keys": false,
-  "keys_directory_path": "<optional: path_of_the_keys_directory>"
+  "use_encrypted_keys": false
 }

--- a/watchtower-operator/config/l2-operator-config.json.template
+++ b/watchtower-operator/config/l2-operator-config.json.template
@@ -1,17 +1,16 @@
 {
   "watchtower_private_keys": [
-    "<WatchTower1-private-key-name>",
-    "<WatchTower2-private-key-name>",
-    "<WatchTower3-private-key-name>"
+    "<alternate-path(optional) + WatchTower1-private-key-name>",
+    "<alternate-path(optional) + WatchTower2-private-key-name>",
+    "<alternate-path(optional) + WatchTower3-private-key-name>"
   ],
-  "operator_private_key": "<operator-private-key-name>",
+  "operator_private_key": "<alternate-path(optional) + operator-private-key-name>",
   "operator_registry_address": "0xEf1a89841fd189ba28e780A977ca70eb1A5e985D",
   "eth_rpc_url": "<Mainnet RPC URL>",
   "chain_id": 1,
   "gas_limit": "<gas-limit>",
   "tx_receipt_timeout": "<timeout_in_seconds>",
   "expiry": "<expiry_in_days>",
-  "use_encrypted_keys": false,
-  "keys_directory_path": "<optional: path_of_the_keys_directory>"
+  "use_encrypted_keys": false
 }
 


### PR DESCRIPTION
Now the user can mention full key path and alternate key paths. 

If only the file name is mentioned then the default path will be used and if the whole path is mentioned the whole path is used. 
But all the keys in one config should be present in the same path, having different keys in different path will get complex because each directory might have it's own password  